### PR TITLE
fix copy and paste

### DIFF
--- a/src/elm/API/Serialization.elm
+++ b/src/elm/API/Serialization.elm
@@ -365,7 +365,7 @@ decodeObject =
         |> optional "bold" D.bool Defaults.bold
         |> optional "url" D.string ""
         |> optional "shape" D.string "rectangle"
-        |> required "updateAt" D.float
+        |> optional_ "updateAt" D.float
 
 
 decodeSearchResult : Decoder (Maybe SearchResult)
@@ -481,7 +481,7 @@ decodeDesk =
         |> optional "bold" D.bool Defaults.bold
         |> optional "url" D.string ""
         |> optional "shape" D.string "rectangle"
-        |> required "updateAt" D.float
+        |> optional_ "updateAt" D.float
 
 
 decodeFloor : Decoder Floor

--- a/src/elm/Model/ClipboardData.elm
+++ b/src/elm/Model/ClipboardData.elm
@@ -62,8 +62,18 @@ fromObjects objects =
 
 toObjects : String -> List Object
 toObjects s =
-    Decode.decodeString (Decode.list Serialization.decodeObject) s
-        |> Result.withDefault []
+    case
+        Decode.decodeString (Decode.list Serialization.decodeObject) s
+    of
+        Ok objects ->
+            objects
+
+        Err message ->
+            let
+                _ =
+                    Debug.log "failed to decode pasting objects" message
+            in
+            []
 
 
 toObjectCandidates : Int -> Size -> Prototype -> Position -> String -> List PositionedPrototype

--- a/src/elm/Model/Object.elm
+++ b/src/elm/Model/Object.elm
@@ -1,6 +1,7 @@
 module Model.Object exposing (..)
 
 import CoreType exposing (..)
+import Time exposing (Time)
 
 
 type Shape
@@ -108,7 +109,12 @@ isLabel (Object object) =
             False
 
 
-initDesk : ObjectId -> FloorId -> Position -> Size -> String -> String -> Float -> Maybe PersonId -> Float -> Object
+futureForInitialUpdateTime : Time
+futureForInitialUpdateTime =
+    32503647600
+
+
+initDesk : ObjectId -> FloorId -> Position -> Size -> String -> String -> Float -> Maybe PersonId -> Maybe Time -> Object
 initDesk id floorId position size backgroundColor name fontSize personId updateAt =
     Object
         { id = id
@@ -119,11 +125,11 @@ initDesk id floorId position size backgroundColor name fontSize personId updateA
         , name = name
         , fontSize = fontSize
         , extension = Desk personId
-        , updateAt = updateAt
+        , updateAt = Maybe.withDefault futureForInitialUpdateTime updateAt
         }
 
 
-initLabel : ObjectId -> FloorId -> Position -> Size -> String -> String -> Float -> LabelFields -> Float -> Object
+initLabel : ObjectId -> FloorId -> Position -> Size -> String -> String -> Float -> LabelFields -> Maybe Time -> Object
 initLabel id floorId position size backgroundColor name fontSize extension updateAt =
     Object
         { id = id
@@ -134,9 +140,7 @@ initLabel id floorId position size backgroundColor name fontSize extension updat
         , name = name
         , fontSize = fontSize
         , extension = Label extension
-
-        -- , updateAt = 32503647600
-        , updateAt = updateAt
+        , updateAt = Maybe.withDefault futureForInitialUpdateTime updateAt
         }
 
 

--- a/src/elm/Page/Map/Update.elm
+++ b/src/elm/Page/Map/Update.elm
@@ -2159,7 +2159,7 @@ updateOnFinishStampWithoutEffects maybeObjectId prototypes model floor =
                         prototype.name
                         prototype.fontSize
                         prototype.personId
-                        32503647600
+                        Nothing
                 )
                 candidatesWithNewIds
 
@@ -2187,7 +2187,7 @@ updateOnFinishPen from model =
                         name
                         Object.defaultFontSize
                         Nothing
-                        32503647600
+                        Nothing
 
                 ( newFloor, objectsChange ) =
                     EditingFloor.updateObjects
@@ -2279,7 +2279,7 @@ updateOnPuttingLabel model =
                         name
                         fontSize
                         (Object.LabelFields color False "" Object.Rectangle)
-                        32503647600
+                        Nothing
 
                 ( newFloor, objectsChange ) =
                     EditingFloor.updateObjects


### PR DESCRIPTION
原因：コピーしたときにクリップボードに保存するために一度シリアライズして、ペースト時にデシリアライズしているが、デシリアライズ（Decode）時に失敗していた。新規作成したオブジェクトには `updateAt` が入っていないため、 `required` でデコードしようとしてこけていた。

修正内容：`Result.withDefault []` で失敗時にエラーを無視していたので、コンソールにログを出すようにした。デコードの `required` を `optional_` に変更した。
