### PR TITLE
Fix: Crash in FullLoaded

### DIFF
--- a/src/elm/Page/Map/Update.elm
+++ b/src/elm/Page/Map/Update.elm
@@ -1415,8 +1415,10 @@ update msg model =
                         OnceLoaded previousResults ->
                             FullLoaded (SearchResult.mergeResults previousResults results)
 
-                        FullLoaded _ ->
-                            Debug.crash "ありえない"
+                        -- Ignore the newly searched result if one already have it.
+                        -- This branch will be executed when performing multiple search actions in a short time.
+                        FullLoaded results ->
+                            FullLoaded results
             }
                 |> Model.cachePeople people
                 |> adjustOffset True


### PR DESCRIPTION
- Ignore the old search result if performing search actions in short time