### PR TITLE
Feature: list edit objects via GraphQL endpoint

### DIFF
--- a/src/elm/API/API.elm
+++ b/src/elm/API/API.elm
@@ -138,12 +138,14 @@ getEditingFloor config floorId =
         graphqlConfig =
             { apiGraphQLRoot = config.apiGraphQLRoot
             , apiKey = config.apiGraphQLKey
+            , apiGraphQLParameter = config.apiGraphQLParameter
             , token = config.token
             }
     in
     Task.map2 Floor.addObjects
-        (API.GraphQL.listEditObjectsOnFloor graphqlConfig floorId
-            |> Http.toTask
+        (API.GraphQL.runListEditObjectsOnFloor
+            graphqlConfig
+            floorId
         )
         (getWithoutCache
             decodeFloor

--- a/src/elm/API/API.elm
+++ b/src/elm/API/API.elm
@@ -28,11 +28,12 @@ module API.API exposing
     )
 
 import API.AuthToken
+import API.GraphQL
 import API.Serialization exposing (..)
 import CoreType exposing (..)
 import Http
 import Model.ColorPalette exposing (ColorPalette)
-import Model.Floor exposing (Floor, FloorBase)
+import Model.Floor as Floor exposing (Floor, FloorBase)
 import Model.FloorInfo exposing (FloorInfo)
 import Model.Object exposing (..)
 import Model.ObjectsChange exposing (ObjectChange)
@@ -55,6 +56,8 @@ type alias Error =
 
 type alias Config =
     { apiRoot : String
+    , apiGraphQLRoot : String
+    , apiGraphQLKey : String
     , cacheRoot : String
     , accountServiceRoot : String
     , profileServiceRoot : String
@@ -130,10 +133,22 @@ deleteEditingFloor config floorId =
 
 getEditingFloor : Config -> FloorId -> Task Error Floor
 getEditingFloor config floorId =
-    getWithoutCache
-        decodeFloor
-        (makeUrl (config.apiRoot ++ "/floors/" ++ floorId ++ "/edit") [])
-        [ authorization config.token ]
+    let
+        graphqlConfig =
+            { apiGraphQLRoot = config.apiGraphQLRoot
+            , apiKey = config.apiGraphQLKey
+            , token = config.token
+            }
+    in
+    Task.map2 Floor.addObjects
+        (API.GraphQL.listEditObjectsOnFloor graphqlConfig floorId
+            |> Http.toTask
+        )
+        (getWithoutCache
+            decodeFloor
+            (makeUrl (config.apiRoot ++ "/floors/" ++ floorId ++ "/edit") [])
+            [ authorization config.token ]
+        )
 
 
 getFloor : Config -> FloorId -> Task Error Floor

--- a/src/elm/API/API.elm
+++ b/src/elm/API/API.elm
@@ -58,6 +58,7 @@ type alias Config =
     { apiRoot : String
     , apiGraphQLRoot : String
     , apiGraphQLKey : String
+    , apiGraphQLParameter : String
     , cacheRoot : String
     , accountServiceRoot : String
     , profileServiceRoot : String

--- a/src/elm/API/GraphQL.elm
+++ b/src/elm/API/GraphQL.elm
@@ -1,4 +1,4 @@
-module API.GraphQL exposing (EditObject, buildSimpleQuery, listEditObjectsOnFloor)
+module API.GraphQL exposing (buildSimpleQuery, listEditObjectsOnFloor)
 
 {-| This module provides GraphQL client for AppSync (see `schema.graphql`)
 There is also a library called `elm-graphql`, you might want to use it instead. (I could not install it in 0.18)
@@ -16,25 +16,6 @@ type alias Config =
     { apiGraphQLRoot : String
     , apiKey : String
     , token : String
-    }
-
-
-type alias EditObject =
-    { backgroundColor : Maybe String
-    , changed : Maybe Bool
-    , deleted : Maybe Bool
-    , floorId : String
-    , height : Maybe Int
-    , id : String
-    , updateAt : Maybe Int
-    , width : Maybe Int
-    , x : Maybe Int
-    , y : Maybe Int
-    , name : Maybe String
-    , personId : Maybe String
-    , fontSize : Maybe Int
-    , typeOf : Maybe String
-    , url : Maybe String
     }
 
 

--- a/src/elm/API/GraphQL.elm
+++ b/src/elm/API/GraphQL.elm
@@ -1,0 +1,96 @@
+module API.GraphQL exposing (EditObject, buildSimpleQuery, listEditObjectsOnFloor)
+
+{-| This module provides GraphQL client for AppSync (see `schema.graphql`)
+There is also a library called `elm-graphql`, you might want to use it instead. (I could not install it in 0.18)
+-}
+
+import API.Serialization
+import Dict exposing (Dict)
+import Http
+import Json.Decode
+import Json.Encode
+import Model.Object exposing (Object)
+
+
+type alias Config =
+    { apiGraphQLRoot : String
+    , apiKey : String
+    , token : String
+    }
+
+
+type alias EditObject =
+    { backgroundColor : Maybe String
+    , changed : Maybe Bool
+    , deleted : Maybe Bool
+    , floorId : String
+    , height : Maybe Int
+    , id : String
+    , updateAt : Maybe Int
+    , width : Maybe Int
+    , x : Maybe Int
+    , y : Maybe Int
+    , name : Maybe String
+    , personId : Maybe String
+    , fontSize : Maybe Int
+    , typeOf : Maybe String
+    , url : Maybe String
+    }
+
+
+{-| Build a simple query, can be used for mutation
+
+    buildSimpleQuery q {a -> xxx, b -> yyy} [id,updatedAt] = { q(a: "xxx", b: "yyy") { id updatedAt } }
+
+-}
+buildSimpleQuery : String -> Dict String String -> List String -> String
+buildSimpleQuery query vars picks =
+    let
+        parameter =
+            List.map (\( k, v ) -> k ++ ": \"" ++ v ++ "\"") (Dict.toList vars) |> String.concat
+
+        response =
+            List.foldl (\label acc -> label ++ " " ++ acc) "" picks
+    in
+    "{ " ++ query ++ "(" ++ parameter ++ ") { " ++ response ++ " } }"
+
+
+listEditObjectsOnFloor : Config -> String -> Http.Request (List Object)
+listEditObjectsOnFloor config floorId =
+    Http.request
+        { method = "POST"
+        , headers =
+            [ Http.header "x-api-key" config.apiKey
+            , Http.header "Authorization" <| "Bearer " ++ config.token
+            , Http.header "Content-Type" "application/graphql"
+            ]
+        , url = config.apiGraphQLRoot
+        , body =
+            Http.jsonBody <|
+                Json.Encode.object <|
+                    (\value -> [ ( "query", Json.Encode.string value ) ]) <|
+                        buildSimpleQuery "listEditObjectsOnFloor"
+                            (Dict.singleton "floorId" floorId)
+                            [ "backgroundColor"
+                            , "changed"
+                            , "deleted"
+                            , "floorId"
+                            , "height"
+                            , "id"
+                            , "updateAt"
+                            , "width"
+                            , "x"
+                            , "y"
+                            , "name"
+                            , "personId"
+                            , "fontSize"
+                            , "type"
+                            , "url"
+                            ]
+        , expect =
+            Http.expectJson <|
+                Json.Decode.at [ "data", "listEditObjectsOnFloor" ] <|
+                    Json.Decode.list API.Serialization.decodeObject
+        , timeout = Nothing
+        , withCredentials = False
+        }

--- a/src/elm/API/GraphQL.elm
+++ b/src/elm/API/GraphQL.elm
@@ -1,4 +1,4 @@
-module API.GraphQL exposing (buildSimpleQuery, listEditObjectsOnFloor)
+module API.GraphQL exposing (buildSimpleQuery, listEditObjectsOnFloor, loadParameterJson)
 
 {-| This module provides GraphQL client for AppSync (see `schema.graphql`)
 There is also a library called `elm-graphql`, you might want to use it instead. (I could not install it in 0.18)
@@ -8,6 +8,7 @@ import API.Serialization
 import Dict exposing (Dict)
 import Http
 import Json.Decode
+import Json.Decode.Pipeline exposing (decode, optional, required)
 import Json.Encode
 import Model.Object exposing (Object)
 
@@ -17,6 +18,21 @@ type alias Config =
     , apiKey : String
     , token : String
     }
+
+
+type alias Info =
+    { url : String
+    , key : String
+    }
+
+
+loadParameterJson : String -> Http.Request Info
+loadParameterJson url =
+    Http.get url
+        (decode Info
+            |> required "url" Json.Decode.string
+            |> required "key" Json.Decode.string
+        )
 
 
 {-| Build a simple query, can be used for mutation

--- a/src/elm/API/GraphQL.elm
+++ b/src/elm/API/GraphQL.elm
@@ -1,4 +1,9 @@
-module API.GraphQL exposing (buildSimpleQuery, listEditObjectsOnFloor, loadParameterJson)
+module API.GraphQL exposing
+    ( buildSimpleQuery
+    , listEditObjectsOnFloor
+    , loadParameterJson
+    , runListEditObjectsOnFloor
+    )
 
 {-| This module provides GraphQL client for AppSync (see `schema.graphql`)
 There is also a library called `elm-graphql`, you might want to use it instead. (I could not install it in 0.18)
@@ -11,11 +16,13 @@ import Json.Decode
 import Json.Decode.Pipeline exposing (decode, optional, required)
 import Json.Encode
 import Model.Object exposing (Object)
+import Task exposing (Task)
 
 
 type alias Config =
     { apiGraphQLRoot : String
     , apiKey : String
+    , apiGraphQLParameter : String
     , token : String
     }
 
@@ -91,3 +98,28 @@ listEditObjectsOnFloor config floorId =
         , timeout = Nothing
         , withCredentials = False
         }
+
+
+{-| (Ugly) workaround for direct reloading.
+Currently, GraphQL Parameter will be loaded once when one opens the map page.
+In this case, opening an edit page and reloading will cause an error in map page
+(since loading edit floor and loading parameter will be both immediately executed when opening the page)
+so if the GraphQL Parameter is not loaded yet, load it instantly.
+
+If `Map.Update.update` could wait until the GraphQL parameter will be loaded or could perform some lazy loading,
+that should be better.
+
+This function also not modifying the model so this won't set the loaded parameter.
+This may cause an inefficient many-time API calls.
+
+-}
+runListEditObjectsOnFloor : Config -> String -> Task Http.Error (List Object)
+runListEditObjectsOnFloor config floorId =
+    (if config.apiGraphQLRoot == "" then
+        Http.toTask (loadParameterJson config.apiGraphQLParameter)
+            |> Task.map (\info -> { config | apiGraphQLRoot = info.url, apiKey = info.key })
+
+     else
+        Task.succeed config
+    )
+        |> Task.andThen (\config -> Http.toTask (listEditObjectsOnFloor config floorId))

--- a/src/elm/Page/Map/Msg.elm
+++ b/src/elm/Page/Map/Msg.elm
@@ -1,4 +1,4 @@
-module Page.Map.Msg exposing (..)
+module Page.Map.Msg exposing (Id, Msg(..), ObjectNameInputMsg(..))
 
 import API.Cache exposing (UserState)
 import Component.FloorDeleter as FloorDeleter
@@ -148,3 +148,4 @@ type Msg
     | FlipFloor
     | ShowInformation Information
     | GotNewToken (Maybe String)
+    | LoadGraphQLInfo { url : String, key : String }

--- a/src/elm/Page/Map/Update.elm
+++ b/src/elm/Page/Map/Update.elm
@@ -72,6 +72,7 @@ type alias Flags =
     { apiRoot : String
     , apiGraphQLRoot : String
     , apiGraphQLKey : String
+    , apiGraphQLParameter : String
     , cacheRoot : String
     , accountServiceRoot : String
     , profileServiceRoot : String
@@ -134,6 +135,7 @@ init flags location =
             { apiRoot = flags.apiRoot
             , apiGraphQLRoot = flags.apiGraphQLRoot
             , apiGraphQLKey = flags.apiGraphQLKey
+            , apiGraphQLParameter = flags.apiGraphQLParameter
             , accountServiceRoot = flags.accountServiceRoot
             , profileServiceRoot = flags.profileServiceRoot
             , cacheRoot = flags.cacheRoot

--- a/src/elm/Page/Map/Update.elm
+++ b/src/elm/Page/Map/Update.elm
@@ -3,6 +3,7 @@ port module Page.Map.Update exposing (Flags, adjustOffset, andThen, batchSave, c
 import API.API as API
 import API.Cache as Cache exposing (UserState)
 import API.Cache2 as Cache2
+import API.GraphQL as GraphQL
 import API.Page as Page
 import Component.FloorDeleter as FloorDeleter
 import Component.FloorProperty as FloorProperty
@@ -70,6 +71,8 @@ port print : {} -> Cmd msg
 
 type alias Flags =
     { apiRoot : String
+    , apiGraphQLRoot : String
+    , apiGraphQLKey : String
     , cacheRoot : String
     , accountServiceRoot : String
     , profileServiceRoot : String
@@ -130,6 +133,8 @@ init flags location =
 
         apiConfig =
             { apiRoot = flags.apiRoot
+            , apiGraphQLRoot = flags.apiGraphQLRoot
+            , apiGraphQLKey = flags.apiGraphQLKey
             , accountServiceRoot = flags.accountServiceRoot
             , profileServiceRoot = flags.profileServiceRoot
             , cacheRoot = flags.cacheRoot

--- a/src/elm/Page/Map/Update.elm
+++ b/src/elm/Page/Map/Update.elm
@@ -3,7 +3,6 @@ port module Page.Map.Update exposing (Flags, adjustOffset, andThen, batchSave, c
 import API.API as API
 import API.Cache as Cache exposing (UserState)
 import API.Cache2 as Cache2
-import API.GraphQL as GraphQL
 import API.Page as Page
 import Component.FloorDeleter as FloorDeleter
 import Component.FloorProperty as FloorProperty

--- a/src/elm/Page/Map/Update.elm
+++ b/src/elm/Page/Map/Update.elm
@@ -3,6 +3,7 @@ port module Page.Map.Update exposing (Flags, adjustOffset, andThen, batchSave, c
 import API.API as API
 import API.Cache as Cache exposing (UserState)
 import API.Cache2 as Cache2
+import API.GraphQL as GraphQL
 import API.Page as Page
 import Component.FloorDeleter as FloorDeleter
 import Component.FloorProperty as FloorProperty
@@ -201,6 +202,7 @@ initCmd apiConfig needsEditMode defaultUserState selectedFloor =
             |> performAPI (\userState -> Initialize needsEditMode selectedFloor userState)
         , API.sustainToken apiConfig
             |> performAPI GotNewToken
+        , performAPI LoadGraphQLInfo (Http.toTask <| GraphQL.loadParameterJson apiConfig.apiGraphQLParameter)
         ]
 
 
@@ -1974,6 +1976,16 @@ update msg model =
 
         ShowInformation information ->
             ( { model | information = information }, Cmd.none )
+
+        LoadGraphQLInfo info ->
+            let
+                oldApiConfig =
+                    model.apiConfig
+
+                newApiConfig =
+                    { oldApiConfig | apiGraphQLRoot = info.url, apiGraphQLKey = info.key }
+            in
+            ( { model | apiConfig = newApiConfig }, Cmd.none )
 
 
 andThen : (Model -> ( Model, Cmd Msg )) -> ( Model, Cmd Msg ) -> ( Model, Cmd Msg )

--- a/src/elm/Page/Master/Update.elm
+++ b/src/elm/Page/Master/Update.elm
@@ -36,6 +36,7 @@ init flags =
             { apiRoot = flags.apiRoot
             , apiGraphQLRoot = flags.apiGraphQLRoot
             , apiGraphQLKey = flags.apiGraphQLKey
+            , apiGraphQLParameter = "" -- We don't use GraphQL API for master page
             , cacheRoot = ""
             , accountServiceRoot = flags.accountServiceRoot
             , profileServiceRoot = ""

--- a/src/elm/Page/Master/Update.elm
+++ b/src/elm/Page/Master/Update.elm
@@ -1,4 +1,4 @@
-module Page.Master.Update exposing (..)
+module Page.Master.Update exposing (Flags, init, initCmd, performAPI, saveColorDebounceConfig, saveColorPalette, savePrototype, savePrototypeDebounceConfig, subscriptions, update, updatePalette)
 
 import API.API as API
 import API.Cache as Cache exposing (UserState)
@@ -20,6 +20,8 @@ import Util.ListUtil as ListUtil
 
 type alias Flags =
     { apiRoot : String
+    , apiGraphQLRoot : String
+    , apiGraphQLKey : String
     , accountServiceRoot : String
     , authToken : String
     , title : String
@@ -32,6 +34,8 @@ init flags =
     let
         apiConfig =
             { apiRoot = flags.apiRoot
+            , apiGraphQLRoot = flags.apiGraphQLRoot
+            , apiGraphQLKey = flags.apiGraphQLKey
             , cacheRoot = ""
             , accountServiceRoot = flags.accountServiceRoot
             , profileServiceRoot = ""
@@ -43,6 +47,7 @@ init flags =
             Cache.defaultUserState
                 (if flags.lang == "ja" then
                     JA
+
                  else
                     EN
                 )
@@ -67,6 +72,7 @@ initCmd apiConfig defaultUserState =
             (\user ->
                 if not (User.isAdmin user) then
                     Task.succeed NotAuthorized
+
                 else
                     Cache.getWithDefault Cache.cache defaultUserState
                         |> Task.andThen
@@ -128,6 +134,7 @@ update removeToken message model =
                 colorPalette =
                     (if isBackground then
                         ColorPalette.addBackgroundColorToLast
+
                      else
                         ColorPalette.addTextColorToLast
                     )
@@ -141,6 +148,7 @@ update removeToken message model =
                 colorPalette =
                     (if isBackground then
                         ColorPalette.deleteBackgroundColorAt
+
                      else
                         ColorPalette.deleteTextColorAt
                     )
@@ -154,6 +162,7 @@ update removeToken message model =
                 colorPalette =
                     (if isBackground then
                         ColorPalette.setBackgroundColorAt
+
                      else
                         ColorPalette.setTextColorAt
                     )

--- a/src/template/index.html
+++ b/src/template/index.html
@@ -40,6 +40,8 @@
 			// [Math.floor(Math.random()*0xFFFFFFFF), Math.floor(Math.random()*0xFFFFFFFF)]
 			visitDate: new Date().getTime(),
 			apiRoot: dynamicOptions.apiRoot || '<%= apiRoot %>',
+			apiGraphQLRoot: dynamicOptions.apiGraphQLRoot || '<%= apiGraphQLRoot %>',
+			apiGraphQLKey: dynamicOptions.apiGraphQLKey || '<%= apiGraphQLKey %>',
 			cacheRoot: dynamicOptions.cacheRoot || '<%= cacheRoot %>',
 			accountServiceRoot: '<%= accountServiceRoot %>',
 			profileServiceRoot: '<%= profileServiceRoot %>',

--- a/src/template/index.html
+++ b/src/template/index.html
@@ -40,8 +40,9 @@
 			// [Math.floor(Math.random()*0xFFFFFFFF), Math.floor(Math.random()*0xFFFFFFFF)]
 			visitDate: new Date().getTime(),
 			apiRoot: dynamicOptions.apiRoot || '<%= apiRoot %>',
-			apiGraphQLRoot: dynamicOptions.apiGraphQLRoot || '<%= apiGraphQLRoot %>',
-			apiGraphQLKey: dynamicOptions.apiGraphQLKey || '<%= apiGraphQLKey %>',
+			apiGraphQLParameter: dynamicOptions.apiGraphQLParameter || '<%= apiGraphQLParameter %>',
+			apiGraphQLRoot: '',
+			apiGraphQLKey: '',
 			cacheRoot: dynamicOptions.cacheRoot || '<%= cacheRoot %>',
 			accountServiceRoot: '<%= accountServiceRoot %>',
 			profileServiceRoot: '<%= profileServiceRoot %>',

--- a/src/template/master.html
+++ b/src/template/master.html
@@ -33,8 +33,8 @@
 			window.navigator.browserLanguage;
 		var main = Elm.Page.Master.Main.fullscreen({
 			apiRoot: '<%= apiRoot %>',
-			apiGraphQLRoot: '<%= apiGraphQLRoot %>',
-			apiGraphQLKey: '<%= apiGraphQLKey %>',
+			apiGraphQLRoot: '',
+			apiGraphQLKey: '',
 			accountServiceRoot: '<%= accountServiceRoot %>',
 			title: '<%= title %>',
 			authToken: localStorage.getItem('authToken') || '',

--- a/src/template/master.html
+++ b/src/template/master.html
@@ -33,6 +33,8 @@
 			window.navigator.browserLanguage;
 		var main = Elm.Page.Master.Main.fullscreen({
 			apiRoot: '<%= apiRoot %>',
+			apiGraphQLRoot: '<%= apiGraphQLRoot %>',
+			apiGraphQLKey: '<%= apiGraphQLKey %>',
 			accountServiceRoot: '<%= accountServiceRoot %>',
 			title: '<%= title %>',
 			authToken: localStorage.getItem('authToken') || '',


### PR DESCRIPTION
- Use GraphQL endpoint for listEditObjects on edit floor
- Configure GraphQL endpoint in `config.*.json`
- Load GraphQL parameters via json file in S3