### PR TITLE
Feature: context menu on panel

### DIFF
--- a/src/elm/Model/Floor.elm
+++ b/src/elm/Model/Floor.elm
@@ -34,6 +34,7 @@ module Model.Floor exposing
     , objects
     , objectsDictFromList
     , partiallyChangeObjects
+    , partiallyChangeRelatedPersons
     , paste
     , patchObjectsByDiffs
     , pixelToReal
@@ -374,6 +375,31 @@ partiallyChangeObjects f ids floor =
             ids
                 |> List.foldl
                     (\objectId dict -> Dict.update objectId (Maybe.map f) dict)
+                    floor.objects
+    }
+
+
+{-| Similar to `partiallyChangeObjects`, but only act on the objects personId attached.
+-}
+partiallyChangeRelatedPersons : (PersonId -> Object -> Object) -> List ObjectId -> Floor -> Floor
+partiallyChangeRelatedPersons f ids floor =
+    { floor
+        | objects =
+            ids
+                |> List.foldl
+                    (\objectId dict ->
+                        Dict.update objectId
+                            (\mayObject ->
+                                mayObject
+                                    |> Maybe.map
+                                        (\object ->
+                                            Object.relatedPerson object
+                                                |> Maybe.map (\personId -> f personId object)
+                                                |> Maybe.withDefault object
+                                        )
+                            )
+                            dict
+                    )
                     floor.objects
     }
 

--- a/src/elm/Model/I18n.elm
+++ b/src/elm/Model/I18n.elm
@@ -1,4 +1,63 @@
-module Model.I18n exposing (..)
+module Model.I18n exposing
+    ( Language(..)
+    , additions
+    , cancel
+    , changes
+    , changesFromDate
+    , close
+    , confirm
+    , conflictSomeoneHasAlreadyChangedPleaseRefreshAndTryAgain
+    , copyAndCreateTemporaryFloor
+    , copyFloor
+    , copyFloorWithEmptyDesks
+    , deleteFloor
+    , deletions
+    , detachProfiles
+    , displayingLinkToObject
+    , download
+    , edit
+    , flipFloor
+    , goToManual
+    , goToMaster
+    , heightMeter
+    , help
+    , lastUpdateByAt
+    , loadImage
+    , mailAddress
+    , missing
+    , modifications
+    , name
+    , networkErrorDetectedPleaseRefreshAndTryAgain
+    , noName
+    , nothingFound
+    , order
+    , password
+    , pickupFirstWord
+    , print
+    , publish
+    , publishingInProgressPreaseWaitForSeconds
+    , registerAsStamp
+    , removeSpaces
+    , rotate
+    , save
+    , search
+    , searchPlaceHolder
+    , searchSamePost
+    , selectIsland
+    , selectSameColor
+    , selectSamePost
+    , signIn
+    , signInTo
+    , signOut
+    , successfullyPublished
+    , timeout
+    , unexpectedBadStatus
+    , unexpectedBadUrl
+    , unexpectedFileError
+    , unexpectedHtmlError
+    , unexpectedPayload
+    , widthMeter
+    )
 
 
 type Language
@@ -84,6 +143,16 @@ removeSpaces lang =
 
         EN ->
             "Remove spaces"
+
+
+detachProfiles : Language -> String
+detachProfiles lang =
+    case lang of
+        JA ->
+            "プロフィールの紐付けを解除し氏名を削除する"
+
+        EN ->
+            "Detach profiles and remove names from those objects"
 
 
 copyFloor : Language -> String

--- a/src/elm/Model/I18n.elm
+++ b/src/elm/Model/I18n.elm
@@ -46,6 +46,7 @@ module Model.I18n exposing
     , selectIsland
     , selectSameColor
     , selectSamePost
+    , setAccordion
     , signIn
     , signInTo
     , signOut
@@ -669,3 +670,21 @@ noName lang =
 
         EN ->
             "(no name)"
+
+
+setAccordion : Language -> Bool -> String
+setAccordion lang folded =
+    case lang of
+        JA ->
+            if folded then
+                "展開する"
+
+            else
+                "折りたたむ"
+
+        EN ->
+            if folded then
+                "Unfold"
+
+            else
+                "Fold"

--- a/src/elm/Page/Map/CanvasView.elm
+++ b/src/elm/Page/Map/CanvasView.elm
@@ -1,6 +1,5 @@
 module Page.Map.CanvasView exposing (temporaryStampView, view)
 
-import ContextMenu
 import CoreType exposing (..)
 import Dict exposing (..)
 import Html exposing (..)

--- a/src/elm/Page/Map/CanvasView.elm
+++ b/src/elm/Page/Map/CanvasView.elm
@@ -19,7 +19,6 @@ import Model.Scale as Scale exposing (Scale)
 import Model.User as User
 import Mouse
 import Native.ClipboardData
-import Page.Map.ContextMenuContext exposing (ContextMenuContext(ObjectContextMenu))
 import Page.Map.GridLayer as GridLayer
 import Page.Map.KeyOperation as KeyOperation
 import Page.Map.Model as Model exposing (DraggingContext(..), Model)
@@ -55,17 +54,14 @@ viewModeEventOptions id =
 editModeEventOptions : Bool -> ObjectId -> ObjectView.EventOptions Msg
 editModeEventOptions isAdmin id =
     if isAdmin then
-        { onContextMenu =
-            Just
-                (ContextMenu.open ContextMenuMsg (ObjectContextMenu id)
-                    |> Attributes.map (BeforeContextMenuOnObject id)
-                )
+        { onContextMenu = Nothing
         , onMouseDown = Just (onMouseDownAttribute isAdmin id)
         , onMouseUp = Just (MouseUpOnObject id)
         , onClick = Just NoOp
         , onStartEditingName = Nothing -- Just (StartEditObject id)
         , onStartResize = Just (MouseDownOnResizeGrip id)
         }
+
     else
         { onContextMenu = Nothing
         , onMouseDown = Just (onMouseDownAttribute isAdmin id)
@@ -160,6 +156,7 @@ objectViewHelp eventOptions isEditMode isGhost selected scale object =
             isGhost
             isEditMode
             scale
+
     else
         ObjectView.viewDesk
             eventOptions
@@ -242,6 +239,7 @@ profilePopupView : Model -> Floor -> Html Msg
 profilePopupView model floor =
     if Mode.isPrintMode model.mode then
         text ""
+
     else
         model.selectedResult
             |> Maybe.andThen
@@ -295,6 +293,7 @@ canvasView model floor =
         gridLayer =
             if Mode.isEditMode model.mode then
                 GridLayer.view model floor
+
             else
                 text ""
 
@@ -306,6 +305,7 @@ canvasView model floor =
             , ( "name-input"
               , if isEditMode then
                     nameInput
+
                 else
                     text ""
               )
@@ -356,6 +356,7 @@ canvasView model floor =
         children3 =
             if isEditMode then
                 ( "canvas-temporary-pen", temporaryPenView model ) :: temporaryStampsView model
+
             else
                 []
     in
@@ -398,6 +399,7 @@ canvasViewStyles model floor =
     , ( "transition"
       , if model.transition then
             "top 0.3s ease, left 0.3s ease"
+
         else
             ""
       )
@@ -405,6 +407,7 @@ canvasViewStyles model floor =
         ++ CommonStyles.noUserSelect
         ++ (if Mode.isViewMode model.mode then
                 [ ( "overflow", "hidden" ) ]
+
             else
                 []
            )
@@ -420,6 +423,7 @@ objectsView model floor =
                     , lazy2 printModeObjectView model.scale object
                     )
                 )
+
     else if Mode.isViewMode model.mode then
         Floor.objects floor
             |> List.map
@@ -435,6 +439,7 @@ objectsView model floor =
                     , lazy2 viewModeObjectView model.scale object
                     )
                 )
+
     else
         case model.draggingContext of
             MoveObject _ start ->
@@ -466,10 +471,12 @@ compareZIndex : ( Object, Bool ) -> ( Int, Int, Float )
 compareZIndex ( object, selected ) =
     ( if selected then
         1
+
       else
         0
     , if Object.isLabel object then
         1
+
       else
         0
     , Object.updateAtOf object
@@ -506,6 +513,7 @@ objectsViewWhileMoving model floor start =
                             (Object.positionOf object)
                 in
                 Object.changePosition newPosition object
+
             else
                 object
 
@@ -570,6 +578,7 @@ objectsViewWhileResizing model floor id from =
                     |> Maybe.map (\( pos, size ) -> object |> Object.changePosition pos |> Object.changeSize size)
                     |> Maybe.withDefault object
                 -- TODO don't allow 0 width/height objects
+
             else
                 object
 
@@ -627,6 +636,7 @@ canvasImageStyle flipImage size =
     , ( "transform"
       , if flipImage then
             "scale(-1,-1)"
+
         else
             ""
       )
@@ -720,6 +730,7 @@ canvasContainerStyle mode rangeSelectMode =
     , ( "background"
       , if Mode.isPrintMode mode then
             "#ddd"
+
         else
             "#000"
       )
@@ -727,6 +738,7 @@ canvasContainerStyle mode rangeSelectMode =
     , ( "cursor"
       , if crosshair then
             "crosshair"
+
         else
             "default"
       )

--- a/src/elm/Page/Map/ContextMenu.elm
+++ b/src/elm/Page/Map/ContextMenu.elm
@@ -1,12 +1,9 @@
 module Page.Map.ContextMenu exposing (view)
 
 import ContextMenu
-import Dict
 import Html exposing (..)
 import Model.EditingFloor as EditingFloor
-import Model.Floor as Floor
 import Model.I18n as I18n
-import Model.Object as Object
 import Model.User as User
 import Page.Map.ContextMenuContext exposing (..)
 import Page.Map.Model exposing (DraggingContext(..), Model)
@@ -25,52 +22,6 @@ view model =
 toItemGroups : Model -> ContextMenuContext -> List (List ( ContextMenu.Item, Msg ))
 toItemGroups model context =
     case context of
-        ObjectContextMenu id ->
-            let
-                itemsForPerson =
-                    model.floor
-                        |> Maybe.andThen
-                            (\eFloor ->
-                                Floor.getObject id (EditingFloor.present eFloor)
-                                    |> Maybe.andThen
-                                        (\obj ->
-                                            Object.relatedPerson obj
-                                                |> Maybe.andThen
-                                                    (\personId ->
-                                                        Dict.get personId model.personInfo
-                                                            |> Maybe.map
-                                                                (\person ->
-                                                                    [ ( ContextMenu.itemWithAnnotation (I18n.selectSamePost model.lang) person.post, SelectSamePost person.post )
-                                                                    , ( ContextMenu.itemWithAnnotation (I18n.searchSamePost model.lang) person.post, SearchByPost person.post )
-                                                                    ]
-                                                                )
-                                                    )
-                                        )
-                            )
-
-                forOneDesk =
-                    if [ id ] == model.selectedObjects then
-                        Maybe.withDefault [] itemsForPerson
-                            ++ [ ( ContextMenu.item (I18n.selectIsland model.lang), SelectIsland id )
-                               , ( ContextMenu.item (I18n.selectSameColor model.lang), SelectSameColor id )
-                               , ( ContextMenu.item (I18n.registerAsStamp model.lang), RegisterPrototype id )
-                               ]
-
-                    else
-                        []
-
-                common =
-                    [ ( ContextMenu.item (I18n.pickupFirstWord model.lang), FirstNameOnly model.selectedObjects )
-                    , ( ContextMenu.item (I18n.removeSpaces model.lang), RemoveSpaces model.selectedObjects )
-                    , ( ContextMenu.item (I18n.rotate model.lang), RotateObjects model.selectedObjects )
-                    , ( ContextMenu.item (I18n.detachProfiles model.lang), DetachProfiles model.selectedObjects )
-                    ]
-
-                items =
-                    forOneDesk ++ common
-            in
-            [ items ]
-
         FloorInfoContextMenu floorId ->
             if Maybe.map (EditingFloor.present >> .id) model.floor == Just floorId then
                 if User.isGuest model.user then

--- a/src/elm/Page/Map/ContextMenu.elm
+++ b/src/elm/Page/Map/ContextMenu.elm
@@ -1,16 +1,16 @@
 module Page.Map.ContextMenu exposing (view)
 
+import ContextMenu
 import Dict
 import Html exposing (..)
-import ContextMenu
-import Model.User as User
-import Model.Object as Object
 import Model.EditingFloor as EditingFloor
-import Model.I18n as I18n
 import Model.Floor as Floor
-import Page.Map.Msg exposing (..)
-import Page.Map.Model exposing (Model, DraggingContext(..))
+import Model.I18n as I18n
+import Model.Object as Object
+import Model.User as User
 import Page.Map.ContextMenuContext exposing (..)
+import Page.Map.Model exposing (DraggingContext(..), Model)
+import Page.Map.Msg exposing (..)
 
 
 view : Model -> Html Msg
@@ -50,11 +50,12 @@ toItemGroups model context =
 
                 forOneDesk =
                     if [ id ] == model.selectedObjects then
-                        (Maybe.withDefault [] itemsForPerson)
+                        Maybe.withDefault [] itemsForPerson
                             ++ [ ( ContextMenu.item (I18n.selectIsland model.lang), SelectIsland id )
                                , ( ContextMenu.item (I18n.selectSameColor model.lang), SelectSameColor id )
                                , ( ContextMenu.item (I18n.registerAsStamp model.lang), RegisterPrototype id )
                                ]
+
                     else
                         []
 
@@ -62,25 +63,29 @@ toItemGroups model context =
                     [ ( ContextMenu.item (I18n.pickupFirstWord model.lang), FirstNameOnly model.selectedObjects )
                     , ( ContextMenu.item (I18n.removeSpaces model.lang), RemoveSpaces model.selectedObjects )
                     , ( ContextMenu.item (I18n.rotate model.lang), RotateObjects model.selectedObjects )
+                    , ( ContextMenu.item (I18n.detachProfiles model.lang), DetachProfiles model.selectedObjects )
                     ]
 
                 items =
                     forOneDesk ++ common
             in
-                [ items ]
+            [ items ]
 
         FloorInfoContextMenu floorId ->
             if Maybe.map (EditingFloor.present >> .id) model.floor == Just floorId then
                 if User.isGuest model.user then
                     []
+
                 else if User.isAdmin model.user then
                     [ [ ( ContextMenu.item (I18n.copyFloor model.lang), CopyFloor floorId False )
                       , ( ContextMenu.item (I18n.copyAndCreateTemporaryFloor model.lang), CopyFloor floorId True )
                       ]
                     ]
+
                 else
                     [ [ ( ContextMenu.item (I18n.copyAndCreateTemporaryFloor model.lang), CopyFloor floorId True )
                       ]
                     ]
+
             else
                 []

--- a/src/elm/Page/Map/ContextMenuContext.elm
+++ b/src/elm/Page/Map/ContextMenuContext.elm
@@ -4,5 +4,4 @@ import CoreType exposing (..)
 
 
 type ContextMenuContext
-    = ObjectContextMenu ObjectId
-    | FloorInfoContextMenu FloorId
+    = FloorInfoContextMenu FloorId

--- a/src/elm/Page/Map/Model.elm
+++ b/src/elm/Page/Map/Model.elm
@@ -1,4 +1,4 @@
-module Page.Map.Model exposing (..)
+module Page.Map.Model exposing (DraggingContext(..), Model, SearchResultState(..), adjustOffset, cachePeople, candidatesOf, canvasPosition, encodeToUrl, expandOrShrinkToward, getEditingFloor, getEditingFloorOrDummy, getPositionedPrototype, headerHeight, init, isMouseInCanvas, nextObjectToInput, primarySelectedObject, screenToImageWithOffset, selectedObjects, shiftSelectionToward, sideMenuWidth, startEdit, syncSelectedByRect, temporaryPen, temporaryPenRect, temporaryResizeRect, toUrl, updateSelectorRect, validateRect)
 
 import API.API as API
 import API.Cache as Cache exposing (Cache)
@@ -31,6 +31,7 @@ import Page.Map.ClipboardOptionsView as ClipboardOptionsView
 import Page.Map.ContextMenuContext exposing (ContextMenuContext)
 import Page.Map.ObjectNameInput as ObjectNameInput exposing (ObjectNameInput)
 import Page.Map.URL as URL exposing (URL)
+import Set exposing (Set)
 import Time exposing (Time)
 import Util.DictUtil as DictUtil
 import Util.IdGenerator as IdGenerator exposing (Seed)
@@ -77,6 +78,7 @@ type alias Model =
     , saveFloorDebounce : Debounce SaveRequest
     , floorDeleter : FloorDeleter
     , transition : Bool
+    , foldedCards : Set String -- Component-local state, should not be here actually...
     }
 
 
@@ -161,6 +163,7 @@ init apiConfig title initialSize randomSeed visitDate isEditMode query objectId 
     , saveFloorDebounce = Debounce.init
     , floorDeleter = FloorDeleter.init
     , transition = False
+    , foldedCards = Set.empty
     }
 
 
@@ -278,6 +281,7 @@ adjustOffset toCenter model =
                                             in
                                             Position (windowCenter.x - objectCenter.x) (windowCenter.y - objectCenter.y)
                                                 |> Scale.screenToImageForPosition model.scale
+
                                         else
                                             let
                                                 containerSize =
@@ -311,6 +315,7 @@ nextObjectToInput object allObjects =
             (\o ->
                 if Object.idOf object == Object.idOf o then
                     Nothing
+
                 else
                     Just o
             )
@@ -505,6 +510,7 @@ validateRect leftTop rightBottom =
     in
     if width > 0 && height > 0 then
         Just ( leftTop, Size width height )
+
     else
         Nothing
 
@@ -535,6 +541,7 @@ toUrl model =
     , query =
         if String.length model.searchQuery == 0 then
             Nothing
+
         else
             Just model.searchQuery
     , objectId =

--- a/src/elm/Page/Map/Msg.elm
+++ b/src/elm/Page/Map/Msg.elm
@@ -151,3 +151,4 @@ type Msg
     | GotNewToken (Maybe String)
     | LoadGraphQLInfo { url : String, key : String }
     | PatchEditObjects (List Model.Floor.ObjectDiff)
+    | ToggleCard String

--- a/src/elm/Page/Map/Msg.elm
+++ b/src/elm/Page/Map/Msg.elm
@@ -93,6 +93,7 @@ type Msg
     | RotateObjects (List ObjectId)
     | FirstNameOnly (List Id)
     | RemoveSpaces (List Id)
+    | DetachProfiles (List Id)
     | HeaderMsg Header.Msg
     | SignIn
     | SignOut

--- a/src/elm/Page/Map/PropertyView.elm
+++ b/src/elm/Page/Map/PropertyView.elm
@@ -3,16 +3,16 @@ module Page.Map.PropertyView exposing (view)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Lazy as Lazy
-import View.Styles as S
-import View.CommonStyles as CS
-import View.Icons as Icons
-import View.Common exposing (..)
-import Util.HtmlUtil exposing (..)
+import Model.ColorPalette exposing (ColorPalette)
 import Model.Object as Object exposing (Object)
 import Model.ObjectsOperation as ObjectsOperation
-import Model.ColorPalette exposing (ColorPalette)
+import Page.Map.Model as Model exposing (DraggingContext(..), Model)
 import Page.Map.Msg exposing (..)
-import Page.Map.Model as Model exposing (Model, DraggingContext(..))
+import Util.HtmlUtil exposing (..)
+import View.Card exposing (..)
+import View.CommonStyles as CS
+import View.Icons as Icons
+import View.Styles as S
 
 
 view : Model -> List (Html Msg)
@@ -21,30 +21,36 @@ view model =
         selectedObjects =
             Model.selectedObjects model
     in
-        if selectedObjects == [] then
-            []
-        else
-            [ if List.all Object.backgroundColorEditable selectedObjects then
-                formControl [ Lazy.lazy label Icons.backgroundColorPropLabel, Lazy.lazy2 backgroundColorView model.colorPalette selectedObjects ]
-              else
-                text ""
-            , if List.all Object.colorEditable selectedObjects then
-                formControl [ Lazy.lazy label Icons.colorPropLabel, Lazy.lazy2 colorView model.colorPalette selectedObjects ]
-              else
-                text ""
-            , if List.all Object.shapeEditable selectedObjects then
-                formControl [ Lazy.lazy label Icons.shapePropLabel, Lazy.lazy shapeView selectedObjects ]
-              else
-                text ""
-            , if List.all Object.fontSizeEditable selectedObjects then
-                formControl [ Lazy.lazy label Icons.fontSizePropLabel, Lazy.lazy fontSizeView selectedObjects ]
-              else
-                text ""
-            , if List.all Object.urlEditable selectedObjects then
-                formControl [ label (text "URL"), urlView (List.head selectedObjects) ]
-              else
-                text ""
-            ]
+    if selectedObjects == [] then
+        []
+
+    else
+        [ if List.all Object.backgroundColorEditable selectedObjects then
+            formControl [ Lazy.lazy label Icons.backgroundColorPropLabel, Lazy.lazy2 backgroundColorView model.colorPalette selectedObjects ]
+
+          else
+            text ""
+        , if List.all Object.colorEditable selectedObjects then
+            formControl [ Lazy.lazy label Icons.colorPropLabel, Lazy.lazy2 colorView model.colorPalette selectedObjects ]
+
+          else
+            text ""
+        , if List.all Object.shapeEditable selectedObjects then
+            formControl [ Lazy.lazy label Icons.shapePropLabel, Lazy.lazy shapeView selectedObjects ]
+
+          else
+            text ""
+        , if List.all Object.fontSizeEditable selectedObjects then
+            formControl [ Lazy.lazy label Icons.fontSizePropLabel, Lazy.lazy fontSizeView selectedObjects ]
+
+          else
+            text ""
+        , if List.all Object.urlEditable selectedObjects then
+            formControl [ label (text "URL"), urlView (List.head selectedObjects) ]
+
+          else
+            text ""
+        ]
 
 
 
@@ -85,9 +91,9 @@ paletteView toMsg selectedColor colors =
                 Nothing ->
                     False
     in
-        ul
-            [ style S.colorProperties ]
-            (List.map (paletteViewEach toMsg match) colors)
+    ul
+        [ style S.colorProperties ]
+        (List.map (paletteViewEach toMsg match) colors)
 
 
 paletteViewEach : (String -> Msg) -> (String -> Bool) -> String -> Html Msg
@@ -124,9 +130,9 @@ shapeView selectedObjects =
                 Object.Ellipse ->
                     Icons.shapeEllipse
     in
-        ul
-            [ style S.shapeProperties ]
-            (List.map (shapeViewEach SelectShape match toIcon) shapes)
+    ul
+        [ style S.shapeProperties ]
+        (List.map (shapeViewEach SelectShape match toIcon) shapes)
 
 
 shapeViewEach : (Object.Shape -> Msg) -> (Object.Shape -> Bool) -> (Object.Shape -> Html Msg) -> Object.Shape -> Html Msg
@@ -158,9 +164,9 @@ fontSizeViewHelp toMsg selectedFontSize sizes =
                 Nothing ->
                     False
     in
-        ul
-            [ style S.colorProperties ]
-            (List.map (fontSizeViewEach toMsg match) sizes)
+    ul
+        [ style S.colorProperties ]
+        (List.map (fontSizeViewEach toMsg match) sizes)
 
 
 fontSizeViewEach : (Float -> Msg) -> (Float -> Bool) -> Float -> Html Msg

--- a/src/elm/Page/Map/SelectedObjectsActions.elm
+++ b/src/elm/Page/Map/SelectedObjectsActions.elm
@@ -1,0 +1,80 @@
+module Page.Map.SelectedObjectsActions exposing (view)
+
+import CoreType exposing (..)
+import Dict
+import Html exposing (..)
+import Html.Attributes exposing (style)
+import Model.EditingFloor as EditingFloor
+import Model.Floor as Floor
+import Model.I18n as I18n
+import Model.Object as Object
+import Page.Map.Model exposing (DraggingContext(..), Model)
+import Page.Map.Msg exposing (..)
+import Util.HtmlUtil exposing (..)
+import View.Styles as S
+
+
+view : Model -> List (Html Msg)
+view model =
+    constructItems model
+        (\label annotation msg ->
+            button
+                [ onClick_ msg
+                , style S.formButton
+                ]
+                [ text label ]
+        )
+
+
+constructItems : Model -> (String -> Maybe String -> Msg -> result) -> List result
+constructItems model makeItem =
+    Maybe.withDefault []
+        (List.head model.selectedObjects
+            |> Maybe.map (\id -> constructItemsWithId id model makeItem)
+        )
+
+
+constructItemsWithId : ObjectId -> Model -> (String -> Maybe String -> Msg -> result) -> List result
+constructItemsWithId id model makeItem =
+    let
+        itemsForPerson =
+            model.floor
+                |> Maybe.andThen
+                    (\eFloor ->
+                        Floor.getObject id (EditingFloor.present eFloor)
+                            |> Maybe.andThen
+                                (\obj ->
+                                    Object.relatedPerson obj
+                                        |> Maybe.andThen
+                                            (\personId ->
+                                                Dict.get personId model.personInfo
+                                                    |> Maybe.map
+                                                        (\person ->
+                                                            [ makeItem (I18n.selectSamePost model.lang) (Just person.post) (SelectSamePost person.post)
+                                                            , makeItem (I18n.searchSamePost model.lang) (Just person.post) (SearchByPost person.post)
+                                                            ]
+                                                        )
+                                            )
+                                )
+                    )
+
+        forOneDesk =
+            if List.length model.selectedObjects == 1 then
+                Maybe.withDefault [] itemsForPerson
+                    ++ [ makeItem (I18n.selectIsland model.lang) Nothing (SelectIsland id)
+                       , makeItem (I18n.selectSameColor model.lang) Nothing (SelectSameColor id)
+                       , makeItem (I18n.selectSameColor model.lang) Nothing (SelectSameColor id)
+                       , makeItem (I18n.registerAsStamp model.lang) Nothing (RegisterPrototype id)
+                       ]
+
+            else
+                []
+
+        common =
+            [ makeItem (I18n.pickupFirstWord model.lang) Nothing (FirstNameOnly model.selectedObjects)
+            , makeItem (I18n.removeSpaces model.lang) Nothing (RemoveSpaces model.selectedObjects)
+            , makeItem (I18n.rotate model.lang) Nothing (RotateObjects model.selectedObjects)
+            , makeItem (I18n.detachProfiles model.lang) Nothing (DetachProfiles model.selectedObjects)
+            ]
+    in
+    forOneDesk ++ common

--- a/src/elm/Page/Map/Update.elm
+++ b/src/elm/Page/Map/Update.elm
@@ -2115,6 +2115,17 @@ update msg model =
             in
             ( newModel, Cmd.none )
 
+        ToggleCard name ->
+            let
+                toggleInSet t set =
+                    if Set.member t set then
+                        Set.remove t set
+
+                    else
+                        Set.insert t set
+            in
+            ( { model | foldedCards = toggleInSet name model.foldedCards }, Cmd.none )
+
 
 andThen : (Model -> ( Model, Cmd Msg )) -> ( Model, Cmd Msg ) -> ( Model, Cmd Msg )
 andThen update ( model, cmd ) =

--- a/src/elm/Page/Map/Update.elm
+++ b/src/elm/Page/Map/Update.elm
@@ -1415,6 +1415,33 @@ update msg model =
                     , saveCmd
                     )
 
+        DetachProfiles ids ->
+            case model.floor of
+                Nothing ->
+                    ( model, Cmd.none )
+
+                Just editingFloor ->
+                    let
+                        ( newFloor, objectsChange ) =
+                            EditingFloor.updateObjects
+                                (Floor.partiallyChangeRelatedPersons
+                                    (\_ ->
+                                        Object.setPerson Nothing
+                                            >> Object.changeName ""
+                                    )
+                                    ids
+                                )
+                                editingFloor
+
+                        saveCmd =
+                            requestSaveObjectsCmd objectsChange
+                    in
+                    ( { model
+                        | floor = Just newFloor
+                      }
+                    , saveCmd
+                    )
+
         HeaderMsg msg ->
             ( { model | header = Header.update msg model.header }, Cmd.none )
 

--- a/src/elm/Page/Map/View.elm
+++ b/src/elm/Page/Map/View.elm
@@ -31,7 +31,7 @@ import Page.Map.PrototypePreviewView as PrototypePreviewView
 import Page.Map.SearchResultView as SearchResultView
 import Set
 import Util.HtmlUtil exposing (..)
-import View.Common exposing (..)
+import View.Card exposing (..)
 import View.DiffView as DiffView
 import View.Icons as Icons
 import View.SearchInputView as SearchInputView

--- a/src/elm/Page/Map/View.elm
+++ b/src/elm/Page/Map/View.elm
@@ -113,8 +113,8 @@ subViewForEdit model editingMode =
     in
     [ foldableCard (Set.member "editingMode" model.foldedCards) model.lang (ToggleCard "editingMode") False "#eee" Nothing Nothing <| drawingView model editingMode
     , foldableCard (Set.member "propertyView" model.foldedCards) model.lang (ToggleCard "propertyView") False "#eee" Nothing Nothing <| PropertyView.view model
-    , foldableCard (Set.member "selectObjectsMenu" model.foldedCards) model.lang (ToggleCard "selectObjectsMenu") False "#eee" Nothing Nothing <| SelectedObjectsActions.view model
     , viewProfile model
+    , foldableCard (Set.member "selectObjectsMenu" model.foldedCards) model.lang (ToggleCard "selectObjectsMenu") False "#eee" Nothing Nothing <| SelectedObjectsActions.view model
     , foldableCard (Set.member "floorView" model.foldedCards) model.lang (ToggleCard "floorView") False "#eee" Nothing Nothing <| floorView
     ]
 

--- a/src/elm/Page/Map/View.elm
+++ b/src/elm/Page/Map/View.elm
@@ -1,40 +1,41 @@
 module Page.Map.View exposing (view)
 
+import Component.FloorDeleter as FloorDeleter
+import Component.FloorProperty as FloorProperty
+import Component.Header as Header
+import Component.ImageLoader as ImageLoader
 import Dict
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Lazy as Lazy exposing (..)
-import View.Styles as S
-import View.Icons as Icons
-import View.DiffView as DiffView
-import View.Common exposing (..)
-import View.SearchInputView as SearchInputView
-import Component.FloorProperty as FloorProperty
-import Component.Header as Header
-import Component.ImageLoader as ImageLoader
-import Component.FloorDeleter as FloorDeleter
-import Util.HtmlUtil exposing (..)
-import Model.Mode as Mode exposing (Mode(..), EditingMode(..))
-import Model.Prototypes as Prototypes
 import Model.EditingFloor as EditingFloor
 import Model.I18n as I18n exposing (Language)
-import Model.User as User exposing (User)
+import Model.Mode as Mode exposing (EditingMode(..), Mode(..))
 import Model.Object as Object
-import Page.Map.Model as Model exposing (Model, DraggingContext(..))
-import Page.Map.Msg exposing (Msg(..))
+import Model.Prototypes as Prototypes
+import Model.User as User exposing (User)
 import Page.Map.CanvasView as CanvasView
-import Page.Map.PropertyView as PropertyView
+import Page.Map.ClipboardOptionsView as ClipboardOptionsView
 import Page.Map.ContextMenu
+import Page.Map.Emoji as Emoji
+import Page.Map.FloorUpdateInfoView as FloorUpdateInfoView
+import Page.Map.FloorsInfoView as FloorsInfoView
+import Page.Map.MessageBar as MessageBar
+import Page.Map.Model as Model exposing (DraggingContext(..), Model)
+import Page.Map.Msg exposing (Msg(..))
+import Page.Map.ObjectNameInput as ObjectNameInput
+import Page.Map.PrintGuide as PrintGuide
+import Page.Map.ProfilePopup as ProfilePopup
+import Page.Map.PropertyView as PropertyView
 import Page.Map.PrototypePreviewView as PrototypePreviewView
 import Page.Map.SearchResultView as SearchResultView
-import Page.Map.FloorUpdateInfoView as FloorUpdateInfoView
-import Page.Map.Emoji as Emoji
-import Page.Map.FloorsInfoView as FloorsInfoView
-import Page.Map.ObjectNameInput as ObjectNameInput
-import Page.Map.ProfilePopup as ProfilePopup
-import Page.Map.PrintGuide as PrintGuide
-import Page.Map.ClipboardOptionsView as ClipboardOptionsView
-import Page.Map.MessageBar as MessageBar
+import Set
+import Util.HtmlUtil exposing (..)
+import View.Common exposing (..)
+import View.DiffView as DiffView
+import View.Icons as Icons
+import View.SearchInputView as SearchInputView
+import View.Styles as S
 
 
 mainView : Model -> Html Msg
@@ -45,6 +46,7 @@ mainView model =
         , CanvasView.view model
         , if Mode.isPrintMode model.mode then
             text ""
+
           else
             subView model
         , FloorUpdateInfoView.view model
@@ -55,6 +57,7 @@ floorInfoView : Model -> Html Msg
 floorInfoView model =
     if Mode.isPrintMode model.mode then
         text ""
+
     else
         FloorsInfoView.view
             model.ctrl
@@ -70,6 +73,7 @@ subView model =
         searchResultView =
             if Mode.showingSearchResult model.mode then
                 [ searchResultCard model ]
+
             else
                 []
 
@@ -81,7 +85,7 @@ subView model =
                 _ ->
                     []
     in
-        div [ style S.subView ] (searchResultView ++ editView)
+    div [ style S.subView ] (searchResultView ++ editView)
 
 
 subViewForEdit : Model -> EditingMode -> List (Html Msg)
@@ -106,11 +110,11 @@ subViewForEdit model editingMode =
                 _ ->
                     []
     in
-        [ card False "#eee" Nothing Nothing <| drawingView model editingMode
-        , card False "#eee" Nothing Nothing <| PropertyView.view model
-        , viewProfile model
-        , card False "#eee" Nothing Nothing <| floorView
-        ]
+    [ foldableCard (Set.member "editingMode" model.foldedCards) model.lang (ToggleCard "editingMode") False "#eee" Nothing Nothing <| drawingView model editingMode
+    , foldableCard (Set.member "propertyView" model.foldedCards) model.lang (ToggleCard "propertyView") False "#eee" Nothing Nothing <| PropertyView.view model
+    , viewProfile model
+    , foldableCard (Set.member "floorView" model.foldedCards) model.lang (ToggleCard "floorView") False "#eee" Nothing Nothing <| floorView
+    ]
 
 
 viewProfile : Model -> Html Msg
@@ -150,6 +154,7 @@ fileLoadButton : Language -> User -> Html Msg
 fileLoadButton lang user =
     if User.isAdmin user then
         ImageLoader.view lang |> Html.map ImageLoaderMsg
+
     else
         text ""
 
@@ -162,6 +167,7 @@ publishButton lang user =
             , style S.publishButton
             ]
             [ text (I18n.publish lang) ]
+
     else
         text ""
 
@@ -172,8 +178,8 @@ searchResultCard model =
         maxHeight =
             model.windowSize.height - Model.headerHeight
     in
-        card True "#eee" (Just maxHeight) (Just 320) <|
-            SearchResultView.view model
+    card True "#eee" (Just maxHeight) (Just 320) <|
+        SearchResultView.view model
 
 
 drawingView : Model -> EditingMode -> List (Html Msg)
@@ -184,34 +190,37 @@ drawingView model editingMode =
 
         editingLabel =
             ObjectNameInput.isEditing model.objectNameInput
-                && case Model.primarySelectedObject model of
-                    Just object ->
-                        Object.isLabel object
+                && (case Model.primarySelectedObject model of
+                        Just object ->
+                            Object.isLabel object
 
-                    Nothing ->
-                        False
+                        Nothing ->
+                            False
+                   )
     in
-        [ Lazy.lazy modeSelectionView editingMode
-        , if editingLabel then
-            Lazy.lazy Emoji.selector ()
-          else
-            case editingMode of
-                Select ->
-                    Lazy.lazy PrototypePreviewView.view prototypes
+    [ Lazy.lazy modeSelectionView editingMode
+    , if editingLabel then
+        Lazy.lazy Emoji.selector ()
 
-                Stamp ->
-                    Lazy.lazy PrototypePreviewView.view prototypes
+      else
+        case editingMode of
+            Select ->
+                Lazy.lazy PrototypePreviewView.view prototypes
 
-                _ ->
-                    text ""
-        , if editingMode == Select then
-            ClipboardOptionsView.view
-                ClipboardOptionsMsg
-                model.clipboardOptionsForm
-                model.cellSizePerDesk
-          else
-            text ""
-        ]
+            Stamp ->
+                Lazy.lazy PrototypePreviewView.view prototypes
+
+            _ ->
+                text ""
+    , if editingMode == Select then
+        ClipboardOptionsView.view
+            ClipboardOptionsMsg
+            model.clipboardOptionsForm
+            model.cellSizePerDesk
+
+      else
+        text ""
+    ]
 
 
 modeSelectionView : EditingMode -> Html Msg
@@ -231,11 +240,11 @@ modeSelectionViewEach viewIcon currentEditMode targetEditMode =
         selected =
             currentEditMode == targetEditMode
     in
-        div
-            [ style (S.modeSelectionViewEach selected)
-            , onClick_ (ChangeMode targetEditMode)
-            ]
-            [ viewIcon selected ]
+    div
+        [ style (S.modeSelectionViewEach selected)
+        , onClick_ (ChangeMode targetEditMode)
+        ]
+        [ viewIcon selected ]
 
 
 view : Model -> Html Msg
@@ -280,14 +289,14 @@ view model =
                     )
                     model.diff
     in
-        div
-            []
-            [ header
-            , mainView model
-            , diffView
-            , Page.Map.ContextMenu.view model
-            , lazy2 PrintGuide.view model.lang printMode
-            ]
+    div
+        []
+        [ header
+        , mainView model
+        , diffView
+        , Page.Map.ContextMenu.view model
+        , lazy2 PrintGuide.view model.lang printMode
+        ]
 
 
 

--- a/src/elm/Page/Map/View.elm
+++ b/src/elm/Page/Map/View.elm
@@ -29,6 +29,7 @@ import Page.Map.ProfilePopup as ProfilePopup
 import Page.Map.PropertyView as PropertyView
 import Page.Map.PrototypePreviewView as PrototypePreviewView
 import Page.Map.SearchResultView as SearchResultView
+import Page.Map.SelectedObjectsActions as SelectedObjectsActions
 import Set
 import Util.HtmlUtil exposing (..)
 import View.Card exposing (..)
@@ -112,6 +113,7 @@ subViewForEdit model editingMode =
     in
     [ foldableCard (Set.member "editingMode" model.foldedCards) model.lang (ToggleCard "editingMode") False "#eee" Nothing Nothing <| drawingView model editingMode
     , foldableCard (Set.member "propertyView" model.foldedCards) model.lang (ToggleCard "propertyView") False "#eee" Nothing Nothing <| PropertyView.view model
+    , foldableCard (Set.member "selectObjectsMenu" model.foldedCards) model.lang (ToggleCard "selectObjectsMenu") False "#eee" Nothing Nothing <| SelectedObjectsActions.view model
     , viewProfile model
     , foldableCard (Set.member "floorView" model.foldedCards) model.lang (ToggleCard "floorView") False "#eee" Nothing Nothing <| floorView
     ]

--- a/src/elm/Page/Master/View.elm
+++ b/src/elm/Page/Master/View.elm
@@ -1,4 +1,4 @@
-module Page.Master.View exposing (..)
+module Page.Master.View exposing (Size, colorMasterRow, colorMasterView, colorSample, headerView, messageBar, prototypeContainerSize, prototypeMasterRow, prototypeMasterView, prototypeParameter, prototypeParameters, userView, view)
 
 import Component.Header as Header
 import Html exposing (..)
@@ -11,7 +11,7 @@ import Page.Master.Model exposing (Model)
 import Page.Master.Msg exposing (Msg(..))
 import Page.Master.PrototypeForm as PrototypeForm exposing (PrototypeForm)
 import Page.Master.Styles as S
-import View.Common exposing (..)
+import View.Card exposing (..)
 import View.CommonStyles as CS
 import View.MessageBar as MessageBar
 import View.PrototypePreviewView as PrototypePreviewView

--- a/src/elm/View/Card.elm
+++ b/src/elm/View/Card.elm
@@ -1,4 +1,4 @@
-module View.Common exposing
+module View.Card exposing
     ( card
     , foldableCard
     , formControl

--- a/src/elm/View/Common.elm
+++ b/src/elm/View/Common.elm
@@ -1,9 +1,38 @@
-module View.Common exposing (card, formControl)
+module View.Common exposing
+    ( card
+    , foldableCard
+    , formControl
+    )
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Model.I18n as I18n exposing (Language)
 import Util.StyleUtil exposing (..)
 import View.CommonStyles exposing (..)
+import View.Icons as Icons
+
+
+foldableCard : Bool -> Language -> msg -> Bool -> String -> Maybe Int -> Maybe Int -> List (Html msg) -> Html msg
+foldableCard folded lang toggleMsg absolute backgroundColor maxHeight maybeWidth children =
+    card absolute backgroundColor maxHeight maybeWidth <|
+        (if List.isEmpty children then
+            []
+
+         else
+            [ div
+                [ onClick toggleMsg ]
+                [ span [ style [ ( "vertical-align", "middle" ) ] ] [ Icons.accordionPanelToggle folded ]
+                , text (I18n.setAccordion lang folded)
+                ]
+            ]
+        )
+            ++ (if folded then
+                    []
+
+                else
+                    [ div [ style [ ( "margin-top", "0.5em" ) ] ] children ]
+               )
 
 
 card : Bool -> String -> Maybe Int -> Maybe Int -> List (Html msg) -> Html msg
@@ -30,12 +59,14 @@ cardStyles absolute backgroundColor maybeMaxHeight maybeWidth =
            , ( "position"
              , if absolute then
                 "absolute"
+
                else
                 ""
              )
            , ( "z-index"
              , if absolute then
                 "1"
+
                else
                 ""
              )

--- a/src/elm/View/Icons.elm
+++ b/src/elm/View/Icons.elm
@@ -1,4 +1,37 @@
-module View.Icons exposing (..)
+module View.Icons exposing
+    ( accordionPanelToggle
+    , backgroundColorPropLabel
+    , closeButton
+    , colorPropLabel
+    , defaultColor
+    , editingToggle
+    , fontSizePropLabel
+    , headerIconColor
+    , helpButton
+    , labelMode
+    , link
+    , mode
+    , modeColor
+    , penMode
+    , personDetailPopupPersonEmployeeId
+    , personDetailPopupPersonMail
+    , personDetailPopupPersonTel
+    , personMatched
+    , personNotMatched
+    , popupClose
+    , printButton
+    , proplabelColor
+    , saveButton
+    , searchResultClose
+    , searchResultItemPerson
+    , searchResultItemPost
+    , selectMode
+    , shapeEllipse
+    , shapePropLabel
+    , shapeRectangle
+    , stampMode
+    , userMenuToggle
+    )
 
 import Color exposing (Color, white)
 import FontAwesome exposing (..)
@@ -26,6 +59,7 @@ mode f =
         f
             (if selected then
                 white
+
              else
                 modeColor
             )
@@ -146,6 +180,7 @@ printButton : Bool -> Svg msg
 printButton printMode =
     if printMode then
         print defaultColor 22
+
     else
         print headerIconColor 22
 
@@ -154,6 +189,7 @@ saveButton : Bool -> Svg msg
 saveButton printMode =
     if printMode then
         download defaultColor 22
+
     else
         download headerIconColor 22
 
@@ -162,6 +198,7 @@ closeButton : Bool -> Svg msg
 closeButton printMode =
     if printMode then
         close defaultColor 22
+
     else
         close headerIconColor 22
 
@@ -175,8 +212,21 @@ userMenuToggle : Bool -> Svg msg
 userMenuToggle open =
     (if open then
         caret_up
+
      else
         caret_down
     )
         white
+        16
+
+
+accordionPanelToggle : Bool -> Svg msg
+accordionPanelToggle folded =
+    (if folded then
+        caret_right
+
+     else
+        caret_down
+    )
+        defaultColor
         16

--- a/src/elm/View/Styles.elm
+++ b/src/elm/View/Styles.elm
@@ -177,8 +177,9 @@ subView : S
 subView =
     [ ( "z-index", zIndex.subView )
     , ( "width", "320px" )
-    , ( "position", "absolute" )
+    , ( "position", "relative" )
     , ( "right", "0" )
+    , ( "overflow-y", "scroll" )
     ]
 
 
@@ -301,15 +302,18 @@ formButton =
 
 
 imageLoadButton : S
-imageLoadButton = formButton
+imageLoadButton =
+    formButton
 
 
 imageDownloadButton : S
-imageDownloadButton = formButton
+imageDownloadButton =
+    formButton
 
 
 flipButton : S
-flipButton = formButton
+flipButton =
+    formButton
 
 
 publishButton : S

--- a/src/elm/View/Styles.elm
+++ b/src/elm/View/Styles.elm
@@ -1,4 +1,4 @@
-module View.Styles exposing (..)
+module View.Styles exposing (S, candidateItem, candidateItemHeight, candidateItemHover, candidateItemPersonMail, candidateItemPersonName, candidateItemPersonPost, candidateViewPointer, candidatesView, candidatesViewContainer, candidatesViewRelatedPerson, closePrint, colorProperties, colorProperty, defaultBar, defaultPopup, deleteFloorButton, deleteFloorButtonHover, deskInput, diffPopupBody, diffPopupCancelButton, diffPopupConfirmButton, diffPopupFooter, diffPopupHeader, diffPopupInnerContainer, editingToggleContainer, editingToggleIcon, editingToggleText, errorBar, flipButton, floorNameInput, floorNameInputContainer, floorNameLabel, floorNameText, floorOrdInput, floorOrdInputContainer, floorOrdLabel, floorOrdText, floorPropertyLabel, floorPropertyLastUpdate, floorPropertyLastUpdateForPrint, floorPropertyText, floorSizeInputContainer, formButton, greetingImage, greetingName, h1, header, headerHeight, headerLink, headerMenu, headerMenuItem, imageDownloadButton, imageLoadButton, langSelectView, langSelectViewItem, login, mainView, messageBar, modeSelectionView, modeSelectionViewEach, nameInputContainer, nameInputTextArea, noneBar, pasteFromSpreadsheetInput, personDetailPopup, personDetailPopupClose, personDetailPopupDefault, personDetailPopupNoPerson, personDetailPopupPersonEmployeeId, personDetailPopupPersonIconText, personDetailPopupPersonImage, personDetailPopupPersonMail, personDetailPopupPersonName, personDetailPopupPersonNo, personDetailPopupPersonPost, personDetailPopupPersonTel, personDetailPopupPointer, personDetailPopupPointerDefault, personDetailPopupPointerSmall, personDetailPopupSmall, personMatched, personMatchingInfo, personNotMatched, popupPointerBase, popupPointerButtom, popupPointerLeft, printModeHover, propertyViewPropertyIcon, prototypePreviewScroll, prototypePreviewView, prototypePreviewViewInner, publishButton, realSizeInput, searchBox, searchBoxContainer, searchBoxSubmit, searchResult, searchResultClose, searchResultGroup, searchResultGroupHeader, searchResultGroupHeaderHover, searchResultItem, searchResultItemIcon, searchResultItemInner, searchResultItemInnerLabel, shadow, shapeProperties, shapeProperty, smallPopup, subView, successBar, unsetRelatedPersonButton, unsetRelatedPersonButtonHover, userMenuItem, userMenuToggle, userMenuToggleIcon, userMenuView, widthHeightLabel, zFloorInfo, zIndex, zPrintGuide)
 
 import CoreType exposing (..)
 import Model.ProfilePopupLogic as ProfilePopupLogic
@@ -80,6 +80,7 @@ header printMode =
                 , ( "z-index", zIndex.headerForPrint )
                 , ( "width", "100%" )
                 ]
+
             else
                 [ ( "color", "#eee" )
                 , ( "background", "rgb(100,100,120)" )
@@ -127,12 +128,14 @@ colorProperty color selected =
     , ( "border-width"
       , if selected then
             "2px"
+
         else
             "1px"
       )
     , ( "border-color"
       , if selected then
             selectColor
+
         else
             "#666"
       )
@@ -156,12 +159,14 @@ shapeProperty selected =
     , ( "border-width"
       , if selected then
             "2px"
+
         else
             "1px"
       )
     , ( "border-color"
       , if selected then
             selectColor
+
         else
             "#666"
       )
@@ -199,12 +204,14 @@ modeSelectionViewEach selected =
     , ( "background-color"
       , if selected then
             selectColor
+
         else
             "inherit"
       )
     , ( "color"
       , if selected then
             invertedTextColor
+
         else
             "inherit"
       )
@@ -247,6 +254,7 @@ prototypePreviewScroll : Bool -> S
 prototypePreviewScroll isLeft =
     ( if isLeft then
         "left"
+
       else
         "right"
     , "3px"
@@ -287,19 +295,21 @@ floorPropertyText =
     ]
 
 
-imageLoadButton : S
-imageLoadButton =
+formButton : S
+formButton =
     formControl ++ defaultButton
+
+
+imageLoadButton : S
+imageLoadButton = formButton
 
 
 imageDownloadButton : S
-imageDownloadButton =
-    formControl ++ defaultButton
+imageDownloadButton = formButton
 
 
 flipButton : S
-flipButton =
-    formControl ++ defaultButton
+flipButton = formButton
 
 
 publishButton : S
@@ -779,6 +789,7 @@ personDetailPopupPersonTel second =
            , ( "left"
              , if second then
                 "180px"
+
                else
                 "100px"
              )
@@ -812,6 +823,7 @@ candidatesViewContainer screenPosOfDesk screenSizeOfDesk relatedPersonExists can
         totalHeight =
             (if relatedPersonExists then
                 160
+
              else
                 0
             )
@@ -874,6 +886,7 @@ candidateItem selected =
     , ( "background-color"
       , if selected then
             hoverBackgroundColor
+
         else
             "#fff"
       )
@@ -1046,6 +1059,7 @@ searchResultItem draggable =
                 , ( "cursor", "move" )
                 ]
                     ++ noUserSelect
+
             else
                 []
            )
@@ -1088,5 +1102,6 @@ nameInputContainer =
 (?) condition a =
     if condition then
         a
+
     else
         ""


### PR DESCRIPTION
- Use Foldable Card in the edit panel on right
- Show actions on selected objects on the edit panel
- Remove object-related context menu (floor context menu is still available)
- Use `position: relative` instead of absolute to show the scrollbar (is this actually safe?)

Screenshot:

![image](https://user-images.githubusercontent.com/1870091/61624639-f4575b80-acb3-11e9-8953-95f5d075780e.png)
